### PR TITLE
Adding participant information page

### DIFF
--- a/workshop/HOME.md
+++ b/workshop/HOME.md
@@ -16,7 +16,6 @@ Dates: {{site.start_date}} through {{site.end_date}}
 
 * Please review the [Code of Conduct](../code-of-conduct.md).
 * If you are new to using R, we've [assembled some resources for getting starting with R](../additional-resources/R-resources.md#pre-workshop-prep-for-r-programming) that can optionally help prepare you for the workshop.
-* Please review the [Participant Information](local-participant-information.md) page for details about the workshop location and other logistics.
 
 ### Setup instructions
 

--- a/workshop/HOME.md
+++ b/workshop/HOME.md
@@ -16,6 +16,7 @@ Dates: {{site.start_date}} through {{site.end_date}}
 
 * Please review the [Code of Conduct](../code-of-conduct.md).
 * If you are new to using R, we've [assembled some resources for getting starting with R](../additional-resources/R-resources.md#pre-workshop-prep-for-r-programming) that can optionally help prepare you for the workshop.
+* Please review the [Participant Information](local-participant-information.md) page for details about the workshop location and other logistics.
 
 ### Setup instructions
 

--- a/workshop/local-participant-information.md
+++ b/workshop/local-participant-information.md
@@ -2,65 +2,48 @@
 <!-- Please update this file to reflect logistics for the workshop being taught. -->
 
 
-
 ## Workshop Location
 
-**The workshop will be held at** [**One Bala Plaza, Bala Cynwyd, PA 19004**](https://www.google.com/maps/place/One+Bala+Plaza/@40.0073079,-75.2221085,17z/data=!3m1!4b1!4m5!3m4!1s0x89c6b89e7102a3b5:0x77dce0b150a7df52!8m2!3d40.0073798!4d-75.2199724?utm_campaign=CCDL_Workshops&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz--pRa135WXpaamTCddydLZAXVv6QwBlCpR9HqVWrGN1EmHMVqdhOeW6wlCMhaR6eCaT1Ekh), just outside of Philadelphia.
-We will meet in the Amenity Suite located on the lower level.
-Enter the building through the Center Lobby and take the elevator down one floor (labeled "LL").
-The Amenity Suite is the first room you will see after exiting the elevator.
-Please note that Bala Plaza is an office park with multiple buildings.
-If you have trouble finding the building or the room on the first day of training, please use Slack to [direct message](/software-setup/slack-procedures.html#using-direct-messages-during-training) `Jen O'Malley`.
- {% comment %}
- NOTE: `html` relative link above is used since this is an included file.
- {% endcomment %}
+The Bulk RNA-Sequencing and Reproducible Research Practices Workshop will be held at the University of Minnesota in the building located at **717 Delaware Street SE, Minneapolis, MN 55414. 
+We will meet in Room 105.**
+Enter through the front main entrance.
 
-## Travel logistics
-### Transportation
+If you have trouble finding the building or the room on the first day of training, please use Slack to direct message `Jen O'Malley`.
 
-**Driving**
+## Pre-workshop Information
 
-* There is free onsite parking available both in front of and behind One Bala Plaza.
+**Please review and sign our waivers:**
 
-**Public transportation**
+* [Training waiver](https://app.hellosign.com/s/2o2yghCj)
+* [Data use waiver](https://app.hellosign.com/s/7AZ7TWXe)
 
-* SEPTA is the public transportation system in Philadelphia and the surrounding area.
-* At the airport, and at some SEPTA train stations, you can purchase a SEPTA key card. There are a variety of fare options that can be loaded onto a key card for use on public transportation. SEPTA also accepts cash for travel on any of its transit services.
-* Please refer to the [SEPTA website](https://www5.septa.org/travel/) for more information. (**Note:** The [SEPTA trip planner](https://beta-plan.septa.org/#/) may be a helpful tool if you plan to travel around the city during your stay.)
+**Here is the [link to join the Slack group](http://ccdatalab.org/slack)** that we will use for communication purposes and to stay in touch after the workshop! 
+You will be added to our `#2024-august-training` channel. 
 
-**Other**
+This is a hands on workshop!
 
-* Many of the hotels in the area are within walking distance, or are a short Uber or Lyft ride, to One Bala Plaza.
+* **Be sure to review the [pre-workshop setup items (on the homepage)](https://alexslemonade.github.io/2024-august-training/)** for instructions on preparing your computer. 
+* **We will hold pre-workshop office hours on Friday, August 16** from 2-3pm CDT (3-4pm EDT) on Slack. 
+Join us on the `#2024-august-training` channel for help getting setup and to ask any questions.
 
-#### Nearby Lodging
+We will provide breakfast, lunch, snacks, and beverages each day. 
+**Please [submit the meal form](https://docs.google.com/forms/d/e/1FAIpQLScSyz_zzW7O7CZn6zPtQPOwSmW-oASgzTTgz34v3YUcpmeEmQ/viewform)** to make us aware of any dietary restrictions and to RSVP for an (optional) group dinner at nearby Surly Brewing Co. on August 20! 
 
-The following hotels are within 1 mile of the workshop location.
 
-* [Courtyard by Marriott Philadelphia City Avenue](https://www.marriott.com/en-us/hotels/phlav-courtyard-philadelphia-city-avenue/overview/)
-* [Hilton Philadelphia City Avenue](https://www.hilton.com/en/hotels/phlphhf-hilton-philadelphia-city-avenue/)
-* [Homewood Suites by Hilton Philadelphia-City Avenue](https://www.hilton.com/en/hotels/phlcahw-homewood-suites-philadelphia-city-avenue)
-* [Residence Inn Philadelphia Bala Cynwyd](https://www.marriott.com/en-us/hotels/phlrb-residence-inn-philadelphia-bala-cynwyd/overview/)
+## Nearby Accommodations
 
-### Travel Reimbursement
+If you are traveling to the workshop, the following hotels are located within 1 mile.
 
-Travel reimbursement up to $500 is available for participants who reside more than 50 miles from the workshop location.
-If you requested travel reimbursement, you will receive a reimbursement form after the workshop ends.
-Payments are typically processed within a few weeks.
-You are responsible for making your own travel and lodging arrangements.
-If you require travel reimbursement of more than $500 to attend, please email training@ccdatalab.org.
-We will evaluate such requests on a case-by-case basis.
+* [Hilton Garden Inn Minneapolis University Area] (https://www.hilton.com/en/hotels/msputgi-hilton-garden-inn-minneapolis-university-area) 
+* [Hampton Inn & Suites Minneapolis University Area] (https://www.hilton.com/en/hotels/mspuahx-hampton-suites-minneapolis-university-area/)
+* [Home2 Suites by Hilton Minneapolis University Area](https://www.hilton.com/en/hotels/msptcht-home2-suites-minneapolis-university-area/) 
 
-To qualify for reimbursement:
-
-* You will need to have included this request in your application.
-* You will be required to provide documentation of travel expenses, such as transportation and lodging receipts, and to fill out a reimbursement form after the workshop ends.
-* You must attend the entirety of the workshop.
 
 ## Health and Safety
 
 Alex's Lemonade Stand Foundation's Childhood Cancer Data Lab will comply with any governmental requirements related to health and safety.
 We encourage workshop participants to adhere to US governmental guidance.
-You may wish to review the [CDC COVID-19 by County guidance](https://www.cdc.gov/coronavirus/2019-ncov/your-health/covid-by-county.html) when planning for workshop attendance.
+You may wish to review the [CDC COVID-19 data tracker](https://covid.cdc.gov/covid-data-tracker/#datatracker-home) when planning for workshop attendance.
 
 If you are feeling sick, please do not attend the workshop.
 We will not withhold your deposit if you cannot attend because you are sick.

--- a/workshop/local-participant-information.md
+++ b/workshop/local-participant-information.md
@@ -34,8 +34,8 @@ We will provide breakfast, lunch, snacks, and beverages each day.
 
 If you are traveling to the workshop, the following hotels are located within 1 mile.
 
-* [Hilton Garden Inn Minneapolis University Area] (https://www.hilton.com/en/hotels/msputgi-hilton-garden-inn-minneapolis-university-area) 
-* [Hampton Inn & Suites Minneapolis University Area] (https://www.hilton.com/en/hotels/mspuahx-hampton-suites-minneapolis-university-area/)
+* [Hilton Garden Inn Minneapolis University Area](https://www.hilton.com/en/hotels/msputgi-hilton-garden-inn-minneapolis-university-area) 
+* [Hampton Inn & Suites Minneapolis University Area](https://www.hilton.com/en/hotels/mspuahx-hampton-suites-minneapolis-university-area/)
 * [Home2 Suites by Hilton Minneapolis University Area](https://www.hilton.com/en/hotels/msptcht-home2-suites-minneapolis-university-area/) 
 
 

--- a/workshop/local-participant-information.md
+++ b/workshop/local-participant-information.md
@@ -22,9 +22,9 @@ You will be added to our `#2024-august-training` channel. 
 
 This is a hands on workshop!
 
-* **Be sure to review the [pre-workshop setup items (on the homepage)](https://alexslemonade.github.io/2024-august-training/)** for instructions on preparing your computer. 
+* **Be sure to review the [Setup Instructions (on the homepage)](https://alexslemonade.github.io/2024-august-training/#setup-instructions)** for instructions on preparing your computer. 
 * **We will hold pre-workshop office hours on Friday, August 16** from 2-3pm CDT (3-4pm EDT) on Slack. 
-Join us on the `#2024-august-training` channel for help getting setup and to ask any questions.
+Join us on the `#2024-august-training` channel for help getting set up and to ask any questions.
 
 We will provide breakfast, lunch, snacks, and beverages each day. 
 **Please [submit the meal form](https://docs.google.com/forms/d/e/1FAIpQLScSyz_zzW7O7CZn6zPtQPOwSmW-oASgzTTgz34v3YUcpmeEmQ/viewform)** to make us aware of any dietary restrictions and to RSVP for an (optional) group dinner at nearby Surly Brewing Co. on August 20! 

--- a/workshop/local-participant-information.md
+++ b/workshop/local-participant-information.md
@@ -12,10 +12,7 @@ If you have trouble finding the building or the room on the first day of trainin
 
 ## Pre-workshop Information
 
-**Please review and sign our waivers:**
-
-* [Training waiver](https://app.hellosign.com/s/2o2yghCj)
-* [Data use waiver](https://app.hellosign.com/s/7AZ7TWXe)
+**Please review and sign the [training waiver](https://app.hellosign.com/s/2o2yghCj).**
 
 **Here is the [link to join the Slack group](http://ccdatalab.org/slack)** that we will use for communication purposes and to stay in touch after the workshop! 
 You will be added to our `#2024-august-training` channel. 


### PR DESCRIPTION
This PR addresses #8. I have updated logistical information for participants, except I did not include travel reimbursement. (This only applies to 3 external participants and has already been discussed with them separately.)