### PR TITLE
Fix copy workflow

### DIFF
--- a/.github/workflows/copy-completed-notebooks.yml
+++ b/.github/workflows/copy-completed-notebooks.yml
@@ -74,7 +74,7 @@ jobs:
               ;;
 
             "Bulk RNA-seq")
-              modules=("intro-to-R-tidyverse", "RNA-seq")
+              modules=("intro-to-R-tidyverse" "RNA-seq")
               ;;
           esac
 


### PR DESCRIPTION
We had an extra comma in the GHA to copy notebooks (see failed action: https://github.com/AlexsLemonade/2024-august-training/actions/runs/10303312673/job/28519035387)

I've fixed the action here, and then will fix in `training-specific-template`