### PR TITLE
Update copy-completed-notebooks.yml

### DIFF
--- a/.github/workflows/copy-completed-notebooks.yml
+++ b/.github/workflows/copy-completed-notebooks.yml
@@ -74,7 +74,7 @@ jobs:
               ;;
 
             "Bulk RNA-seq")
-              modules=("intro-to-R-tidyverse" "RNA-seq")
+              modules=("intro-to-R-tidyverse" "RNA-seq" "pathway-analysis")
               ;;
           esac
 


### PR DESCRIPTION
The `pathway-analysis` module was not listed under bulk RNA-seq, but that material is specifically geared towards bulk RNA-seq. We could presumably make this conditional, but it did not seem worth the effort to me.